### PR TITLE
failing spec demonstraing not working delete command

### DIFF
--- a/spec/dummy/app/commands/users.rb
+++ b/spec/dummy/app/commands/users.rb
@@ -4,4 +4,8 @@ ROM.commands(:users) do
     validator UserValidator
     result :one
   end
+
+  define(:delete) do
+    result :one
+  end
 end

--- a/spec/dummy/spec/integration/user_commands_spec.rb
+++ b/spec/dummy/spec/integration/user_commands_spec.rb
@@ -18,4 +18,13 @@ describe 'User commands' do
       expect(result.error.messages[:name]).to include("can't be blank")
     end
   end
+
+  describe 'delete' do
+    it 'deletes record' do
+      users.create.call(name: 'Piotr')
+      result = users.try { delete(:by_name, 'Piotr') }
+
+      expect(result.error).to be(nil)
+    end
+  end
 end

--- a/spec/dummy/spec/integration/user_commands_spec.rb
+++ b/spec/dummy/spec/integration/user_commands_spec.rb
@@ -7,7 +7,7 @@ describe 'User commands' do
     it 'inserts user with valid params' do
       result = users.try { create(name: 'Jade') }
 
-      expect(result.value).to eql(id: 1, name: 'Jade')
+      expect(result.value).to eql(id: result.value[:id], name: 'Jade')
     end
 
     it 'returns error if params are not valid' do


### PR DESCRIPTION
I was following http://rom-rb.org/tutorials/rails/ tutorial and found issue when trying to implement `destroy` action in my rails app.

Running: `users.try { delete(:by_name, 'Piotr') }`
throws:
```
NoMethodError:
  undefined method `size' for #<#<Class:0x007fd82aa522b0>:0x007fd82d3f7d68>
```

I don't know if this is bug in rom-rails or in rom, but definitely when fixed it would be nice to have it covered here.