### PR TITLE
Use Virtus in strict mode to ensure input is coerced

### DIFF
--- a/lib/rom/model.rb
+++ b/lib/rom/model.rb
@@ -37,7 +37,7 @@ module ROM
     module Params
       def self.included(base)
         base.class_eval do
-          include Virtus.model
+          include Virtus.model(strict: true)
           include ActiveModel::Validations
           include ActiveModel::Conversion
         end
@@ -55,6 +55,10 @@ module ROM
 
         def [](input)
           new(input)
+        end
+
+        def attribute(name, type, options = {})
+          super(name, type, { required: false }.merge(options))
         end
       end
     end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe ROM::Model::Params do
+  let(:klass) {
+    Class.new do
+      include ROM::Model::Params
+
+      attribute :name, String
+    end
+  }
+
+  it 'fails loudly when given an incorrect type' do
+    expect {
+      klass.new(name: [])
+    }.to raise_error(Virtus::CoercionError)
+  end
+
+  it 'does not fail on nil or missing attributes' do
+    expect {
+      klass.new
+    }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Ensures attributes are coerced to either the specified type or nil.

As an aside, it would be great if Virtus supported setting the required option on a per model basis, so we didn't have to override `attribute`. Something like `include Virtus.model(strict: true, required: false)`.