### PR TITLE
speed up builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
+sudo: false
+cache: bundler
 bundler_args: --without yard guard benchmarks
 env:
   - CODECLIMATE_REPO_TOKEN=87c9080bda25bce8e63a294f99312345c144c0f6d5eedf400fd753356fbf7dcf
-script: "RAILS_ENV=test rake app:db:schema:load app:spec"
+script: "RAILS_ENV=test bundle exec rake app:db:schema:load app:spec"
 rvm:
   - 2.0
   - 2.1


### PR DESCRIPTION
`sudo: false` enables docker containers: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
`cache: bundler` caches bundled gems between builds