### PR TITLE
Improve configuration API and support for initializers

### DIFF
--- a/lib/rom/rails/configuration.rb
+++ b/lib/rom/rails/configuration.rb
@@ -1,7 +1,7 @@
 module ROM
   module Rails
     class Configuration
-      attr_reader :repos
+      attr_reader :repositories
 
       # Tries to guess the right ROM configuration for a Rails app.
       #
@@ -10,7 +10,7 @@ module ROM
       #
       # @api private
       def self.build(app)
-        new(repos: derive_repos_from_application(app))
+        new(repositories: derive_repos_from_application(app))
       end
 
       # Uses database configuration from Rails to configure repositories.
@@ -30,7 +30,7 @@ module ROM
       end
 
       def initialize(config)
-        @repos = config.fetch(:repos)
+        @repositories = config.fetch(:repositories)
       end
     end
   end

--- a/lib/rom/rails/configuration.rb
+++ b/lib/rom/rails/configuration.rb
@@ -1,17 +1,36 @@
 module ROM
   module Rails
     class Configuration
-      attr_reader :config
+      attr_reader :repos
 
+      # Tries to guess the right ROM configuration for a Rails app.
+      #
+      # @param [Rails::Application] app
+      # @return [Configuration]
+      #
+      # @api private
       def self.build(app)
-        config = app.config.database_configuration[::Rails.env].
-          symbolize_keys.update(root: app.config.root)
+        new(repos: derive_repos_from_application(app))
+      end
 
-        new(ROM::Config.build(config))
+      # Uses database configuration from Rails to configure repositories.
+      #
+      # Note that the `DATABASE_URL` environment variable supported by
+      # ActiveRecord will *NOT* be respected.
+      #
+      # @param [Rails::Application] app
+      # @return [Hash]
+      #
+      # @api private
+      def self.derive_repos_from_application(app)
+        config = app.config.database_configuration[::Rails.env].
+                            symbolize_keys.update(root: app.config.root)
+
+        ROM::Config.build(config)
       end
 
       def initialize(config)
-        @config = config
+        @repos = config.fetch(:repos)
       end
     end
   end

--- a/lib/rom/rails/configuration.rb
+++ b/lib/rom/rails/configuration.rb
@@ -1,7 +1,7 @@
 module ROM
   module Rails
     class Configuration
-      attr_reader :config, :setup, :env
+      attr_reader :config
 
       def self.build(app)
         config = app.config.database_configuration[::Rails.env].
@@ -12,22 +12,6 @@ module ROM
 
       def initialize(config)
         @config = config
-      end
-
-      def setup!
-        @setup = ROM.setup(@config.symbolize_keys)
-      end
-
-      def load!
-        Railtie.load_all
-      end
-
-      def finalize!
-        # rescuing fixes the chicken-egg problem where we have a relation
-        # defined but the table doesn't exist yet
-        @env = ROM.finalize.env
-      rescue Registry::ElementNotFoundError => e
-        warn "Skipping ROM setup => #{e.message}"
       end
     end
   end

--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -41,7 +41,7 @@ module ROM
         require schema_file if schema_file.exist?
       end
 
-      initializer "rom:prepare" do |app|
+      initializer "rom:prepare" do |_app|
         config.to_prepare do |_config|
           Railtie.disconnect
           Railtie.setup!

--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -52,7 +52,7 @@ module ROM
       private
 
       def self.setup!
-        ROM.setup(config.rom.repos.symbolize_keys)
+        ROM.setup(config.rom.repositories.symbolize_keys)
 
         load_all
 

--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -31,7 +31,9 @@ module ROM
         end
       end
 
-      initializer "rom.configure" do |app|
+      # Derive ROM configuration from the application and make it available to
+      # the user via `Rails.application.config` before other initializers run.
+      config.before_initialize do |app|
         config.rom = Configuration.build(app)
       end
 

--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -49,6 +49,23 @@ module ROM
         end
       end
 
+      # Behaves like `Railtie#configure` if the given block does not take any
+      # arguments. Otherwise yields the ROM configuration to the block.
+      #
+      # @example
+      #   ROM::Rails::Railtie.configure do |config|
+      #     config.repositories[:yaml] = {uri: 'yaml:///data'}
+      #   end
+      #
+      # @api public
+      def configure(&block)
+        if block.arity == 1
+          block.call(config.rom)
+        else
+          super
+        end
+      end
+
       private
 
       def self.setup!

--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -52,7 +52,7 @@ module ROM
       private
 
       def self.setup!
-        ROM.setup(config.rom.config.symbolize_keys)
+        ROM.setup(config.rom.repos.symbolize_keys)
 
         load_all
 

--- a/spec/dummy/spec/integration/logger_spec.rb
+++ b/spec/dummy/spec/integration/logger_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'ROM logger' do
-  let(:rom) { Rails.application.config.rom.env }
+  let(:rom) { ROM.env }
 
   it 'sets up rails logger for all repositories' do
     pending 'this will be re-enabled once we have feature detection on ' \

--- a/spec/dummy/spec/integration/user_model_mapping_spec.rb
+++ b/spec/dummy/spec/integration/user_model_mapping_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'User model mapping' do
-  let(:rom) { Rails.application.config.rom.env }
+  let(:rom) { ROM.env }
 
   let(:users) { rom.read(:users) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,5 +25,5 @@ RSpec.configure do |config|
 end
 
 def rom
-  Rails.application.config.rom.env
+  ROM.env
 end


### PR DESCRIPTION
Initializers like the following can now be used to configure repositories:

```ruby
Rails.application.configure do |app|
  app.config.rom.repos[:yaml] = {uri: 'yaml:///config'}
end
```