### PR TITLE
Make inheriting configuration from ActiveRecord more solid.

### DIFF
--- a/lib/rom/rails/active_record/configuration.rb
+++ b/lib/rom/rails/active_record/configuration.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 module ROM
   module Rails
     module ActiveRecord
@@ -5,9 +7,8 @@ module ROM
       #
       # @private
       class Configuration
-        SCHEME_MAP = {'sqlite3' => 'sqlite', 'postgresql' => 'postgres'}.freeze
-
         BASE_OPTIONS = [
+          :root,
           :adapter,
           :database,
           :password,
@@ -41,54 +42,63 @@ module ROM
         #
         # @api private
         def self.build(config)
-          root = config[:root]
+          adapter = config.fetch(:adapter)
+          uri_options = config.except(:adapter).merge(scheme: adapter)
+          other_options = config.except(*BASE_OPTIONS)
 
-          database = config[:database]
-          password = config.fetch(:password) { '' }
-          username = config[:username]
-          hostname = config.fetch(:hostname) { 'localhost' }
+          builder_method = :"#{adapter}_uri"
+          uri = if respond_to?(builder_method)
+                  send(builder_method, uri_options)
+                else
+                  generic_uri(uri_options)
+                end
 
-          raw_scheme = scheme_for_adapter(config[:adapter])
-
-          path =
-            if raw_scheme == 'sqlite'
-              [root, database].compact.join('/')
-            else
-              db_path = [hostname, database].join('/')
-
-              if username && password
-                [[username, password].join(':'), db_path].join('@')
-              else
-                db_path
-              end
-            end
-
-          other_keys = config.keys - BASE_OPTIONS
-          options = Hash[other_keys.zip(config.values_at(*other_keys))]
 
           # JRuby connection strings require special care.
-          scheme = if RUBY_ENGINE == 'jruby'
-                     scheme_for_jruby(scheme)
-                   else
-                     raw_scheme
-                   end
+          uri = if RUBY_ENGINE == 'jruby' && adapter != 'postgresql'
+                  "jdbc:#{uri}"
+                 else
+                   uri
+                 end
 
-          config_hash("#{scheme}://#{path}", options)
+          config_hash(uri, other_options)
         end
 
-        # Returns a Sequel-compatible scheme for an ActiveRecord adapter name.
-        #
-        # @api private
-        def self.scheme_for_adapter(scheme)
-          SCHEME_MAP.fetch(scheme) { |scheme| scheme }
+        def self.sqlite3_uri(config)
+          path = Pathname.new(config.fetch(:root)).join(config.fetch(:database))
+
+          build_uri(
+            scheme: 'sqlite',
+            host: '',
+            path: path.to_s
+          )
         end
 
-        # Rewrites schemes to use JDBC if appropriate.
-        #
-        # @api private
-        def self.scheme_for_jruby(scheme)
-          return scheme if scheme == 'postgres'
-          "jdbc:#{scheme}"
+        def self.postgresql_uri(config)
+          generic_uri(config.merge(scheme: 'postgres'))
+        end
+
+        def self.mysql_uri(config)
+          if config.key?(:username) && !config.key?(:password)
+            config.update(password: '')
+          end
+
+          generic_uri(config)
+        end
+
+        def self.generic_uri(config)
+          build_uri(
+            scheme: config.fetch(:scheme),
+            user: config[:username],
+            password: config[:password],
+            host: config[:host],
+            port: config[:port],
+            path: config[:database]
+          )
+        end
+
+        def self.build_uri(attrs)
+          Addressable::URI.new(attrs).to_s
         end
 
         # @api private

--- a/lib/rom/rails/active_record/configuration.rb
+++ b/lib/rom/rails/active_record/configuration.rb
@@ -1,8 +1,7 @@
 module ROM
   module Rails
     module ActiveRecord
-      # Helper class used by ROM internally to deal with ActiveRecord
-      # configuration hashes.
+      # A helper class to derive a repository configuration from ActiveRecord.
       #
       # @private
       class Configuration
@@ -15,6 +14,20 @@ module ROM
           :root
         ].freeze
 
+        # Returns repository configuration for the current environment.
+        #
+        # @note This relies on ActiveRecord being initialized already.
+        # @param [Rails::Application]
+        #
+        # @api private
+        def self.call(app)
+          configuration = ::ActiveRecord::Base.configurations[::Rails.env]
+                          .symbolize_keys
+                          .update(root: app.config.root)
+
+          build(configuration)
+        end
+
         # Builds a configuration hash from a flat database config hash.
         #
         # This is used to support typical database.yml-complaint configs. It
@@ -26,8 +39,6 @@ module ROM
         #
         # @api private
         def self.build(config, options = {})
-          return config_hash(config, options) if config.is_a?(String)
-
           return config unless config[:database]
 
           root = config[:root]
@@ -64,9 +75,9 @@ module ROM
         # @api private
         def self.config_hash(uri, options = {})
           if options.any?
-            { default: { uri: uri, options: options } }
+            { uri: uri, options: options }
           else
-            { default: uri }
+            uri
           end
         end
       end

--- a/lib/rom/rails/active_record/configuration.rb
+++ b/lib/rom/rails/active_record/configuration.rb
@@ -1,0 +1,75 @@
+module ROM
+  module Rails
+    module ActiveRecord
+      # Helper class used by ROM internally to deal with ActiveRecord
+      # configuration hashes.
+      #
+      # @private
+      class Configuration
+        BASE_OPTIONS = [
+          :adapter,
+          :database,
+          :password,
+          :username,
+          :hostname,
+          :root
+        ].freeze
+
+        # Builds a configuration hash from a flat database config hash.
+        #
+        # This is used to support typical database.yml-complaint configs. It
+        # also uses adapter interface for things that are adapter-specific like
+        # handling schema naming.
+        #
+        # @param [Hash,String]
+        # @return [Hash]
+        #
+        # @api private
+        def self.build(config, options = {})
+          return config_hash(config, options) if config.is_a?(String)
+
+          return config unless config[:database]
+
+          root = config[:root]
+
+          raw_scheme = config[:adapter]
+
+          database = config[:database]
+          password = config.fetch(:password) { '' }
+          username = config[:username]
+          hostname = config.fetch(:hostname) { 'localhost' }
+
+          adapter = Adapter[raw_scheme]
+          scheme = adapter.normalize_scheme(raw_scheme)
+
+          path =
+            if adapter.database_file?(scheme)
+              [root, database].compact.join('/')
+            else
+              db_path = [hostname, database].join('/')
+
+              if username && password
+                [[username, password].join(':'), db_path].join('@')
+              else
+                db_path
+              end
+            end
+
+          other_keys = config.keys - BASE_OPTIONS
+          options = Hash[other_keys.zip(config.values_at(*other_keys))]
+
+          config_hash("#{scheme}://#{path}", options)
+        end
+
+        # @api private
+        def self.config_hash(uri, options = {})
+          if options.any?
+            { default: { uri: uri, options: options } }
+          else
+            { default: uri }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/rails/configuration.rb
+++ b/lib/rom/rails/configuration.rb
@@ -5,15 +5,6 @@ module ROM
     class Configuration
       attr_reader :repositories
 
-      # Tries to guess the right ROM configuration for a Rails app.
-      #
-      # @param [Rails::Application] app
-      # @return [Configuration]
-      #
-      # @api private
-      def self.build(app)
-        new(repositories: derive_repos_from_application(app))
-      end
 
       # Uses database configuration from Rails to configure repositories.
       #
@@ -31,8 +22,8 @@ module ROM
         ActiveRecord::Configuration.build(config)
       end
 
-      def initialize(config)
-        @repositories = config.fetch(:repositories)
+      def initialize(config = Hash.new)
+        @repositories = config.fetch(:repositories) { Hash.new }
       end
     end
   end

--- a/lib/rom/rails/configuration.rb
+++ b/lib/rom/rails/configuration.rb
@@ -5,23 +5,6 @@ module ROM
     class Configuration
       attr_reader :repositories
 
-
-      # Uses database configuration from Rails to configure repositories.
-      #
-      # Note that the `DATABASE_URL` environment variable supported by
-      # ActiveRecord will *NOT* be respected.
-      #
-      # @param [Rails::Application] app
-      # @return [Hash]
-      #
-      # @api private
-      def self.derive_repos_from_application(app)
-        config = app.config.database_configuration[::Rails.env].
-                            symbolize_keys.update(root: app.config.root)
-
-        ActiveRecord::Configuration.build(config)
-      end
-
       def initialize(config = Hash.new)
         @repositories = config.fetch(:repositories) { Hash.new }
       end

--- a/lib/rom/rails/configuration.rb
+++ b/lib/rom/rails/configuration.rb
@@ -1,3 +1,5 @@
+require 'rom/rails/active_record/configuration'
+
 module ROM
   module Rails
     class Configuration
@@ -26,7 +28,7 @@ module ROM
         config = app.config.database_configuration[::Rails.env].
                             symbolize_keys.update(root: app.config.root)
 
-        ROM::Config.build(config)
+        ActiveRecord::Configuration.build(config)
       end
 
       def initialize(config)

--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -11,42 +11,37 @@ end
 module ROM
   module Rails
     class Railtie < ::Rails::Railtie
-      def self.disconnect
-        return unless ROM.env
-
-        ROM.env.repositories.each_value do |repository|
-          repository.adapter.disconnect
+      initializer 'rom.configure_action_controller' do
+        ActiveSupport.on_load(:action_controller) do
+          ActionController::Base.send(:include, ControllerExtension)
         end
       end
 
-      def self.load_all
-        load_schema
-
-        %w(relations mappers commands).each do |type|
-          load_files(type, ::Rails.root)
-        end
+      # Make `ROM::Rails::Configuration` instance available to the user via
+      # `Rails.application.config` before other initializers run.
+      config.before_initialize do |_app|
+        config.rom = Configuration.new
       end
 
-      def self.load_files(type, root)
-        Dir[root.join("app/#{type}/**/*.rb").to_s].each do |path|
-          load(path)
-        end
-      end
-
-      def load_schema
-        load(schema_file) if schema_file.exist?
-      end
-
-      # Derive ROM configuration from the application and make it available to
-      # the user via `Rails.application.config` before other initializers run.
-      config.before_initialize do |app|
-        config.rom = Configuration.build(app)
-      end
-
+      # Reload ROM-related application code on each request.
       config.to_prepare do |_config|
-        Railtie.disconnect
-        Railtie.setup!
-        ActionController::Base.send(:include, ControllerExtension)
+        Railtie.reload if ROM.env
+      end
+
+      # This is where the initial setup of ROM occurs.
+      # TODO: Freeze the configuration.
+      config.after_initialize do |app|
+        # At this point ActiveRecord::Base.configurations are already populated,
+        # but ROM should NOT be yet. Will only be called once.
+        fail if ROM.env
+
+        unless config.rom.repositories.key?(:default)
+          config.rom.repositories.merge!(
+            Configuration.derive_repos_from_application(app)
+          )
+        end
+
+        Railtie.setup
       end
 
       # Behaves like `Railtie#configure` if the given block does not take any
@@ -66,9 +61,18 @@ module ROM
         end
       end
 
-      private
+      def reload
+        Railtie.disconnect
+        Railtie.setup
+      end
 
-      def self.setup!
+      def disconnect
+        ROM.env.repositories.each_value do |repository|
+          repository.adapter.disconnect
+        end
+      end
+
+      def setup
         ROM.setup(config.rom.repositories.symbolize_keys)
 
         load_all
@@ -79,6 +83,24 @@ module ROM
           ROM.finalize.env
         rescue Registry::ElementNotFoundError => e
           warn "Skipping ROM setup => #{e.message}"
+        end
+      end
+
+      def load_all
+        load_schema
+
+        %w(relations mappers commands).each do |type|
+          load_files(type, root)
+        end
+      end
+
+      def load_schema
+        load(schema_file) if schema_file.exist?
+      end
+
+      def load_files(type, root)
+        Dir[root.join("app/#{type}/**/*.rb").to_s].each do |path|
+          load(path)
         end
       end
 

--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -35,10 +35,9 @@ module ROM
         # but ROM should NOT be yet. Will only be called once.
         fail if ROM.env
 
-        unless config.rom.repositories.key?(:default)
-          config.rom.repositories.merge!(
-            Configuration.derive_repos_from_application(app)
-          )
+        if defined?(ActiveRecord)
+          config.rom.repositories[:default] ||= ActiveRecord::Configuration
+                                                .call(app)
         end
 
         Railtie.setup

--- a/spec/lib/active_record/configuration_spec.rb
+++ b/spec/lib/active_record/configuration_spec.rb
@@ -31,8 +31,13 @@ describe ROM::Rails::ActiveRecord::Configuration do
     end
 
     it 'only includes username if no password is given' do
-      pending 'bug in the current implementation'
-      uri = uri_for(adapter: 'postgresql', database: 'test', username: 'user')
+      uri = uri_for(
+        adapter: 'postgresql',
+        host: 'example.com',
+        database: 'test',
+        username: 'user'
+      )
+
       expect(parse(uri).userinfo).to eql('user')
     end
 
@@ -41,7 +46,8 @@ describe ROM::Rails::ActiveRecord::Configuration do
         adapter: 'postgresql',
         database: 'test',
         username: 'user',
-        password: 'password'
+        password: 'password',
+        host: 'example.com'
       )
 
       expect(parse(uri).userinfo).to eql('user:password')
@@ -55,7 +61,7 @@ describe ROM::Rails::ActiveRecord::Configuration do
 
   context 'with mysql adapter' do
     it 'sets default password to an empty string' do
-      uri = uri_for(adapter: 'mysql', database: 'test', username: 'root')
+      uri = uri_for(adapter: 'mysql', database: 'test', username: 'root', host: 'example.com')
       expect(parse(uri).userinfo).to eql('root:')
     end
 

--- a/spec/lib/active_record/configuration_spec.rb
+++ b/spec/lib/active_record/configuration_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+require 'rom/rails/active_record/configuration'
+
+describe ROM::Rails::ActiveRecord::Configuration do
+  let(:root) { Pathname.new('/path/to/app') }
+
+  def uri_for(config)
+    result = read(config)
+    result.is_a?(Hash) ? result[:uri] : result
+  end
+
+  def read(config)
+    result = described_class.build(config.merge(root: root))
+  end
+
+  def parse(uri)
+    URI.parse(uri.gsub(/^jdbc:/, ''))
+  end
+
+  it 'raises an error without specifying a database'
+
+  context 'with postgresql adapter' do
+    it 'rewrites the scheme' do
+      uri = uri_for(adapter: 'postgresql', database: 'test')
+      expect(parse(uri).scheme).to eql('postgres')
+    end
+
+    it 'does not use jdbc even on jruby' do
+      uri = uri_for(adapter: 'postgresql', database: 'test')
+      expect(uri).to_not start_with('jdbc:')
+    end
+
+    it 'only includes username if no password is given' do
+      pending 'bug in the current implementation'
+      uri = uri_for(adapter: 'postgresql', database: 'test', username: 'user')
+      expect(parse(uri).userinfo).to eql('user')
+    end
+
+    it 'includes username and password if both are given' do
+      uri = uri_for(
+        adapter: 'postgresql',
+        database: 'test',
+        username: 'user',
+        password: 'password'
+      )
+
+      expect(parse(uri).userinfo).to eql('user:password')
+    end
+
+    it 'omits userinfo if neither username nor password are given' do
+      uri = uri_for(adapter: 'postgresql', database: 'test')
+      expect(parse(uri).userinfo).to be_nil
+    end
+  end
+
+  context 'with mysql adapter' do
+    it 'sets default password to an empty string' do
+      uri = uri_for(adapter: 'mysql', database: 'test', username: 'root')
+      expect(parse(uri).userinfo).to eql('root:')
+    end
+
+    it 'uses jdbc only on jruby' do
+      uri = uri_for(adapter: 'mysql', database: 'test')
+      expect(uri.starts_with?('jdbc:')).to be(RUBY_ENGINE == 'jruby')
+    end
+  end
+
+  context 'with sqlite3 adapter' do
+    let(:database) { Pathname.new('db/development.sqlite3') }
+    let(:config) { {adapter: adapter, database: database} }
+
+    it 'rewrites the scheme' do
+      uri = uri_for(adapter: 'sqlite3', database: database)
+      expect(parse(uri).scheme).to eql('sqlite')
+    end
+
+    it 'uses jdbc only on jruby' do
+      uri = uri_for(adapter: 'sqlite3', database: database)
+      expect(uri.starts_with?('jdbc:')).to be(RUBY_ENGINE == 'jruby')
+    end
+
+    it 'expands the path' do
+      uri = uri_for(adapter: 'sqlite3', database: database)
+      expect(parse(uri).path).to eql(root.join(database).to_s)
+    end
+  end
+end


### PR DESCRIPTION
I'm starting to tackle rom-rb/rom#92. Support for `ENV['DATABASE_URI']` will come for free. We're moving `ROM::Config` to `rom-rails` as discussed.