### PR TITLE
Reduce duplication with `#timestamps` method

### DIFF
--- a/lib/rom/model.rb
+++ b/lib/rom/model.rb
@@ -58,6 +58,11 @@ module ROM
         def [](input)
           new(input)
         end
+
+        def timestamps
+          attribute :created_at, DateTime, default: proc { DateTime.now }
+          attribute :updated_at, DateTime, default: proc { DateTime.now }
+        end
       end
     end
 

--- a/spec/dummy/spec/integration/user_params_spec.rb
+++ b/spec/dummy/spec/integration/user_params_spec.rb
@@ -9,10 +9,17 @@ describe ROM::Model::Params do
       attribute :name, String
       validates :name, presence: true
 
+      timestamps
+
       def self.name
         'Test'
       end
     end
+  end
+
+  it 'provides a way to specify timestamps with default values' do
+    expect(params.new.created_at).to be_a(DateTime)
+    expect(params.new.updated_at).to be_a(DateTime)
   end
 
   describe '#valid?' do


### PR DESCRIPTION
Fixes #132

Added a `#timestamps` method so that we get two attributes with default
values:

1. `created_at`
2. `updated_at`

Per issue #132, they are `DateTime` instances and their default value is
a proc returning `DateTime.now`.