### PR TITLE
Change `.timestamps` to have variable arity

### DIFF
--- a/lib/rom/rails/model/params.rb
+++ b/lib/rom/rails/model/params.rb
@@ -41,6 +41,8 @@ module ROM
       end
 
       module ClassMethods
+        DEFAULT_TIMESTAMPS = [:created_at, :updated_at].freeze
+
         def [](input)
           input.is_a?(self) ? input : new(input)
         end
@@ -55,8 +57,9 @@ module ROM
 
         def timestamps(*attrs)
           if attrs.empty?
-            attribute :created_at, DateTime, default: proc { DateTime.now }
-            attribute :updated_at, DateTime, default: proc { DateTime.now }
+            DEFAULT_TIMESTAMPS.each do |t|
+              attribute t, DateTime, default: proc { DateTime.now }
+            end
           else
             attrs.each do |attr|
               attribute attr, DateTime, default: proc { DateTime.now }

--- a/lib/rom/rails/model/params.rb
+++ b/lib/rom/rails/model/params.rb
@@ -53,9 +53,15 @@ module ROM
           RUBY
         end
 
-        def timestamps
-          attribute :created_at, DateTime, default: proc { DateTime.now }
-          attribute :updated_at, DateTime, default: proc { DateTime.now }
+        def timestamps(*attrs)
+          if attrs.empty?
+            attribute :created_at, DateTime, default: proc { DateTime.now }
+            attribute :updated_at, DateTime, default: proc { DateTime.now }
+          else
+            attrs.each do |attr|
+              attribute attr, DateTime, default: proc { DateTime.now }
+            end
+          end
         end
       end
     end

--- a/spec/dummy/spec/integration/user_params_spec.rb
+++ b/spec/dummy/spec/integration/user_params_spec.rb
@@ -10,9 +10,39 @@ describe ROM::Model::Params do
       timestamps
     end
   end
+  describe '.timestamps' do
+    it 'provides a way to specify timestamps with default values' do
+      expect(params.new.created_at).to be_a(DateTime)
+      expect(params.new.updated_at).to be_a(DateTime)
+    end
 
-  it 'provides a way to specify timestamps with default values' do
-    expect(params.new.created_at).to be_a(DateTime)
-    expect(params.new.updated_at).to be_a(DateTime)
+    context 'passing in arbritrary names' do
+      it 'excludes :created_at when passing in :updated_at' do
+        params = Class.new {
+          include ROM::Model::Params
+
+          timestamps(:updated_at)
+        }
+
+        model = params.new
+
+        expect(model).not_to respond_to(:created_at)
+        expect(model).to respond_to(:updated_at)
+      end
+
+      it 'accepts multiple timestamp attribute names' do
+        params = Class.new {
+          include ROM::Model::Params
+
+          timestamps(:published_at, :revised_at)
+        }
+
+        model = params.new
+
+        expect(model).to respond_to(:published_at)
+        expect(model).to respond_to(:revised_at)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Previously, `.timestamps` had zero-arity.  It created `created_at`
and `updated_at` timestamps.

This change makes it so you can specify one or more custom timestamps.

See discussion at rom-rb/rom-rails#19