### PR TITLE
form.errors may return a blank ActiveModel::Errors object

### DIFF
--- a/lib/rom/rails/model/form.rb
+++ b/lib/rom/rails/model/form.rb
@@ -32,11 +32,11 @@ module ROM
       end
 
       def success?
-        errors.nil?
+        !errors.any?
       end
 
       def errors
-        result && result.error
+        (result && result.error) || ActiveModel::Errors.new([])
       end
     end
   end

--- a/spec/unit/form_spec.rb
+++ b/spec/unit/form_spec.rb
@@ -149,6 +149,23 @@ describe 'Form' do
     end
   end
 
+  describe "#errors" do
+
+    context "with a new model" do
+      it "exposes an activemodel compatible error"  do
+        errors = form.build({}).errors
+
+        expect(errors).to be_instance_of(
+          ActiveModel::Errors
+        )
+
+        expect(errors[:email]).to eq []
+      end
+    end
+
+  end
+
+
   describe 'inheritance' do
     let(:child_form) do
       Class.new(form) do


### PR DESCRIPTION
A number of form-building libraries, such as simple_form and formtasic,
depend on the active-model errors interface.  They expect Errors to
always be present, never nil,  and to return an empty array for specific
attribute errors.

This bounces forward an empty errors object, when no errors are found in
the result.

Note:  I've only added unit tests for the base, pre-save case.  the
integration specs seem to have driven the change to the success? method
without needing any additional specs