### PR TITLE
Add form#validate! method to run validations

### DIFF
--- a/lib/rom/rails/model/form.rb
+++ b/lib/rom/rails/model/form.rb
@@ -21,8 +21,9 @@ module ROM
 
       def initialize(params = {}, options = {})
         @params = params
-        @model = self.class.model.new(params.merge(options.slice(*self.class.key)))
+        @model  = self.class.model.new(params.merge(options.slice(*self.class.key)))
         @result = nil
+        @errors =  ActiveModel::Errors.new([])
         options.each { |key, value| instance_variable_set("@#{key}", value) }
       end
 
@@ -46,11 +47,7 @@ module ROM
       end
 
       def errors
-        if result
-          result.error
-        else
-          @errors ||=  ActiveModel::Errors.new([])
-        end
+        (result && result.error) || @errors
       end
     end
   end

--- a/lib/rom/rails/model/form.rb
+++ b/lib/rom/rails/model/form.rb
@@ -36,11 +36,21 @@ module ROM
       end
 
       def success?
-        !errors.any?
+        errors.nil? || !errors.any?
+      end
+
+      def validate!
+        self.class::Validator.call(params)
+      rescue ROM::Model::ValidationError => e
+        @errors = e.errors
       end
 
       def errors
-        (result && result.error) || ActiveModel::Errors.new([])
+        if result
+          result.error
+        else
+          @errors ||=  ActiveModel::Errors.new([])
+        end
       end
     end
   end

--- a/lib/rom/rails/model/form.rb
+++ b/lib/rom/rails/model/form.rb
@@ -40,9 +40,9 @@ module ROM
       end
 
       def validate!
-        self.class::Validator.call(params)
-      rescue ROM::Model::ValidationError => e
-        @errors = e.errors
+        validator = self.class::Validator.new(params)
+        validator.validate
+        @errors =  validator.errors
       end
 
       def errors

--- a/lib/rom/rails/model/form.rb
+++ b/lib/rom/rails/model/form.rb
@@ -41,9 +41,10 @@ module ROM
       end
 
       def validate!
-        validator = self.class::Validator.new(params)
+        validator = self.class::Validator.new(attributes)
         validator.validate
-        @errors =  validator.errors
+
+        @errors = validator.errors
       end
 
       def attributes

--- a/lib/rom/rails/model/form.rb
+++ b/lib/rom/rails/model/form.rb
@@ -46,6 +46,10 @@ module ROM
         @errors =  validator.errors
       end
 
+      def attributes
+        self.class.params[params]
+      end
+
       def errors
         (result && result.error) || @errors
       end

--- a/spec/unit/form_spec.rb
+++ b/spec/unit/form_spec.rb
@@ -237,6 +237,33 @@ describe 'Form' do
       expect(form_object.errors[:email]).to include "can't be blank"
     end
 
+    it "uses processed parameters" do
+      form = Class.new(ROM::Model::Form) do
+        def self.name
+          'UserForm'
+        end
+
+        key :foo_id, :bar_id
+
+        input do
+          set_model_name 'User'
+
+          attribute :email, String
+          attribute :country, String, default: "Unkown"
+        end
+
+        validations do
+          validates :email, presence: true
+          validates :country, presence: true
+        end
+      end
+
+      form_object = form.build(uid: "12345")
+      form_object.validate!
+
+      expect(form_object.errors[:country]).to be_blank
+    end
+
   end
 
 

--- a/spec/unit/form_spec.rb
+++ b/spec/unit/form_spec.rb
@@ -207,6 +207,27 @@ describe 'Form' do
     end
   end
 
+  describe "#attributes" do
+    it "returns processed attributes" do
+      form = Class.new(ROM::Model::Form) do
+        def self.name
+          'UserForm'
+        end
+
+        key :foo_id, :bar_id
+
+        input do
+          set_model_name 'User'
+
+          attribute :uid, Integer
+        end
+      end
+
+      form_object = form.build(uid: "12345")
+      expect(form_object.attributes[:uid]).to eq 12345
+    end
+  end
+
   describe "#validate!" do
 
     it "runs validations and assigns errors" do

--- a/spec/unit/form_spec.rb
+++ b/spec/unit/form_spec.rb
@@ -207,6 +207,19 @@ describe 'Form' do
     end
   end
 
+  describe "#validate!" do
+
+    it "runs validations and assigns errors" do
+      form_object = form.build({})
+      form_object.validate!
+
+      expect(form_object.errors[:email]).to include "can't be blank"
+    end
+
+  end
+
+
+
   describe 'inheritance' do
     let(:child_form) do
       Class.new(form) do

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -36,6 +36,16 @@ describe 'Validation' do
     end
   end
 
+  describe "#validate" do
+    let(:params) { {} }
+
+    it "sets errors when params are not valid" do
+      validator.validate
+      expect(validator.errors[:name]).to eql(["can't be blank"])
+    end
+
+  end
+
   describe ':presence' do
     let(:params) { user_params.new(name: '') }
 


### PR DESCRIPTION
This will run the validations without attempting a database
modification; useful for workflows that need to ensure
provided data is good without immediately saving to the datastore.

This relies on the AM#validate method, which is an alias for valid.  The spec on that method ensures that the api doesn't break out from underneath us.  (Okay, so I was surprised when the spec passed before I did anything.  TIL, ActiveModel::Validations defines `validate`)