### PR TITLE
Added explicit require of active_model

### DIFF
--- a/lib/rom/rails/model/validator/uniqueness_validator.rb
+++ b/lib/rom/rails/model/validator/uniqueness_validator.rb
@@ -1,3 +1,5 @@
+require 'active_model/validator'
+
 module ROM
   module Model
     module Validator


### PR DESCRIPTION
In a project which hasn't already required `active_model` elsewhere `ActiveModel::EachValidator` can be undefined by the time rom-rails is required.  Adding this require stops that from being a problem.