### PR TITLE
Look for ActiveRecord in global namespace

### DIFF
--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -79,7 +79,7 @@ module ROM
       end
 
       def infer_default_repository
-        return unless defined?(ActiveRecord)
+        return unless defined?(::ActiveRecord)
         spec = ActiveRecord::Configuration.call
         [:sql, spec[:uri], spec[:options]]
       end


### PR DESCRIPTION
Avoids `uninitialized constant` when ActiveRecord is not used.
Exact error was:
```
/lib/rom/rails/active_record/configuration.rb:27:in `call': uninitialized constant ActiveRecord (NameError)
```