### PR TITLE
Always include a live relation link in generated mappers

### DIFF
--- a/lib/generators/rom/mapper/templates/mapper.rb.erb
+++ b/lib/generators/rom/mapper/templates/mapper.rb.erb
@@ -1,6 +1,6 @@
 class <%= model_name %>Mapper < ROM::Mapper
-  # relation :<%= relation %>
-  #
+  relation :<%= relation %>
+
   # specify model and attributes ie
   #
   # model <%= model_name %>

--- a/spec/lib/generators/mapper_generator_spec.rb
+++ b/spec/lib/generators/mapper_generator_spec.rb
@@ -17,8 +17,8 @@ describe ROM::Generators::MapperGenerator do
           file 'user_mapper.rb' do
             contains <<-CONTENT.strip_heredoc
               class UserMapper < ROM::Mapper
-                # relation :users
-                #
+                relation :users
+              
                 # specify model and attributes ie
                 #
                 # model User


### PR DESCRIPTION
This way, `ROM.finalize` will always be able to build the mapper registry properly on Rails startup, and users can `rails g` as many ROM objects as they like without having to modify them by hand.