### PR TITLE
Child forms inherit attributes

### DIFF
--- a/lib/rom/rails/model/form/class_interface.rb
+++ b/lib/rom/rails/model/form/class_interface.rb
@@ -257,7 +257,7 @@ module ROM
             klass.send(:include, ROM::Model::Attributes)
           }
           @attributes.class_eval(&block)
-          const_set(:Attributes, @attributes)
+          update_const(:Attributes, @attributes)
         end
 
         # Define attribute readers for the form
@@ -308,7 +308,8 @@ module ROM
             RUBY
           }
           key.each { |name| @model.attribute(name) }
-          const_set(:Model, @model)
+
+          update_const(:Model, @model)
         end
 
         # Define attribute validator class
@@ -322,7 +323,7 @@ module ROM
             klass.send(:include, ROM::Model::Validator)
           }
           @validator.class_eval(&block)
-          const_set(:Validator, @validator)
+          update_const(:Validator, @validator)
         end
 
         # Shortcut to global ROM env
@@ -389,6 +390,19 @@ module ROM
           repository.extend_command_class(klass, relation.dataset)
 
           klass.build(relation)
+        end
+
+
+        # Silently update a constant, replacing any existing definition without
+        # warning
+        #
+        # @param [Symbol] name the name of the constant
+        # @param [Class] klass class to assign
+        #
+        # @api private
+        def update_const(name, klass)
+          remove_const(name) if const_defined?(name, false)
+          const_set(name, klass)
         end
       end
     end

--- a/lib/rom/rails/model/form/class_interface.rb
+++ b/lib/rom/rails/model/form/class_interface.rb
@@ -271,12 +271,7 @@ module ROM
         # @api private
         def define_attribute_readers!
           @attributes.attribute_set.each do |attribute|
-            if public_instance_methods.include?(attribute.name)
-              raise(
-                ArgumentError,
-                "#{attribute.name} attribute is in conflict with #{self}##{attribute.name}"
-              )
-            end
+            next if public_instance_methods.include?(attribute.name)
 
             class_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{attribute.name}

--- a/lib/rom/rails/model/form/class_interface.rb
+++ b/lib/rom/rails/model/form/class_interface.rb
@@ -225,6 +225,17 @@ module ROM
 
         private
 
+        # retrieve a list of reserved method names
+        #
+        # @return [Array<Symbol>]
+        #
+        # @api private
+        def reserved_attributes
+          [ :commit!, :save, :attributes, :params, :validator, :errors,
+            :validate!, :result, :model_name, :to_model, :to_key,
+            :persisted?, :success? ]
+        end
+
         # @return [Hash<Symbol=>ROM::CommandRegistry>]
         #
         # @api private
@@ -277,8 +288,14 @@ module ROM
         #
         # @api private
         def define_attribute_readers!
+          reserved = reserved_attributes
           @attributes.attribute_set.each do |attribute|
-            next if public_instance_methods.include?(attribute.name)
+            if reserved.include?(attribute.name)
+              raise(
+                ArgumentError,
+                "#{attribute.name} attribute is in conflict with #{self}##{attribute.name}"
+              )
+            end
 
             class_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{attribute.name}

--- a/lib/rom/rails/model/form/class_interface.rb
+++ b/lib/rom/rails/model/form/class_interface.rb
@@ -231,9 +231,7 @@ module ROM
         #
         # @api private
         def reserved_attributes
-          [ :commit!, :save, :attributes, :params, :validator, :errors,
-            :validate!, :result, :model_name, :to_model, :to_key,
-            :persisted?, :success? ]
+          ROM::Model::Form.public_instance_methods
         end
 
         # @return [Hash<Symbol=>ROM::CommandRegistry>]

--- a/spec/unit/form_spec.rb
+++ b/spec/unit/form_spec.rb
@@ -321,5 +321,33 @@ describe 'Form' do
       )
       expect(child_form.validator).to_not be(form.validator)
     end
+
+    it "expands existing validators" do
+      child_form = Class.new(form) do
+        def self.name
+          "NewUserForm"
+        end
+
+        input do
+          attribute :login, String
+        end
+
+        validations do
+          validates :login, length: { minimum: 4 }
+        end
+      end
+
+      expect(child_form.validator.validators.first).to be_instance_of(
+        ActiveModel::Validations::PresenceValidator
+      )
+
+      expect(child_form.validator.validators.last).to be_instance_of(
+        ActiveModel::Validations::LengthValidator
+      )
+
+      expect(child_form.validator).to_not be(form.validator)
+    end
+
+
   end
 end

--- a/spec/unit/form_spec.rb
+++ b/spec/unit/form_spec.rb
@@ -293,6 +293,23 @@ describe 'Form' do
       expect(child_form.attributes).to_not be(form.attributes)
     end
 
+    it 'expands input' do
+      child_form = Class.new(form) do
+        def self.name
+          "NewUserForm"
+        end
+
+        input do
+          attribute :login, String
+        end
+      end
+
+      expect(child_form.attributes.attribute_set[:login]).to_not be(nil)
+      expect(child_form.attributes.attribute_set[:email]).to_not be(nil)
+
+      expect(child_form.attributes).to_not be(form.attributes)
+    end
+
     it 'copies model' do
       expect(child_form.model.attribute_set[:email]).to_not be(nil)
       expect(child_form.model).to_not be(form.model)

--- a/spec/unit/form_spec.rb
+++ b/spec/unit/form_spec.rb
@@ -116,13 +116,6 @@ describe 'Form' do
     end
 
     it 'raises error when attribute is in conflict with form interface' do
-      pending <<-PENDING.strip_heredoc
-      I've updated the builder to _skip_ already existing methods, rather
-      than raising a warning.
-      1) It's needed for allowing input to be called multiple times
-      2) If you've already defined a method, good on ya?
-      DISCUSS
-      PENDING
       expect {
         Class.new(ROM::Model::Form) do
           input do

--- a/spec/unit/form_spec.rb
+++ b/spec/unit/form_spec.rb
@@ -116,6 +116,13 @@ describe 'Form' do
     end
 
     it 'raises error when attribute is in conflict with form interface' do
+      pending <<-PENDING.strip_heredoc
+      I've updated the builder to _skip_ already existing methods, rather
+      than raising a warning.
+      1) It's needed for allowing input to be called multiple times
+      2) If you've already defined a method, good on ya?
+      DISCUSS
+      PENDING
       expect {
         Class.new(ROM::Model::Form) do
           input do


### PR DESCRIPTION
ref rom-rb/rom#184

This allows for a subclass of a form to use the `input` and `validation` blocks to extend the form definition, without throwing out the existing form information.

Note that  11ac4c1 changes existing behavior by squelching an error that was being thrown.  Discussion welcome.