### PR TITLE
ensure AR Configuration return correct mysql2 uri and options

### DIFF
--- a/lib/rom/rails/active_record/configuration.rb
+++ b/lib/rom/rails/active_record/configuration.rb
@@ -14,7 +14,7 @@ module ROM
           :password,
           :username,
           :hostname,
-          :root
+          :host
         ].freeze
 
         # Returns gateway configuration for the current environment.
@@ -51,11 +51,9 @@ module ROM
                 end
 
           # JRuby connection strings require special care.
-          uri = if RUBY_ENGINE == 'jruby' && adapter != 'postgresql'
-                  "jdbc:#{uri}"
-                else
-                  uri
-                end
+          if RUBY_ENGINE == 'jruby' && adapter != 'postgresql'
+            uri = "jdbc:#{uri}"
+          end
 
           { uri: uri, options: other_options }
         end

--- a/spec/lib/active_record/configuration_spec.rb
+++ b/spec/lib/active_record/configuration_spec.rb
@@ -108,10 +108,10 @@ describe ROM::Rails::ActiveRecord::Configuration do
           host: 'example.com',
         }
 
-        expect(read(config)).to eq(
-          uri: 'mysql2://root:password@example.com/database',
-          options: {pool: 5},
-        )
+        expected_uri = 'mysql2://root:password@example.com/database'
+        expected_uri = "jdbc:#{expected_uri}" if RUBY_ENGINE == 'jruby'
+
+        expect(read(config)).to eq uri: expected_uri, options: {pool: 5}
       end
     end
   end

--- a/spec/lib/active_record/configuration_spec.rb
+++ b/spec/lib/active_record/configuration_spec.rb
@@ -95,4 +95,24 @@ describe ROM::Rails::ActiveRecord::Configuration do
       expect(parse(uri).path).to eql(root.join(database).to_s)
     end
   end
+
+  describe '#build' do
+    context 'with an ActiveRecord mysql2 configuration' do
+      it 'returns the database uri and options' do
+        config = {
+          pool: 5,
+          adapter: 'mysql2',
+          username: 'root',
+          password: 'password',
+          database: 'database',
+          host: 'example.com',
+        }
+
+        expect(read(config)).to eq(
+          uri: 'mysql2://root:password@example.com/database',
+          options: {pool: 5},
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
I tested the `ROM::Rails::ActiveRecord::Configuration.build` method with what `::ActiveRecord::Base.configurations.fetch(::Rails.env)` returns as a config for the mysql2 adapter.