### PR TITLE
Fix Mapper generator register_as line

### DIFF
--- a/lib/generators/rom/mapper_generator.rb
+++ b/lib/generators/rom/mapper_generator.rb
@@ -21,7 +21,7 @@ module ROM
       end
 
       def register_as
-        model_name.singularize.downcase
+        model_name.singularize.underscore.downcase
       end
 
     end

--- a/spec/lib/generators/mapper_generator_spec.rb
+++ b/spec/lib/generators/mapper_generator_spec.rb
@@ -8,6 +8,7 @@ describe ROM::Generators::MapperGenerator do
   before(:all) do
     prepare_destination
     run_generator ['users']
+    run_generator ['app_user']
   end
 
   specify do
@@ -24,6 +25,23 @@ describe ROM::Generators::MapperGenerator do
                 # specify model and attributes ie
                 #
                 # model User
+                #
+                # attribute :name
+                # attribute :email
+              end
+            CONTENT
+          end
+
+          file 'app_user_mapper.rb' do
+            contains <<-CONTENT.strip_heredoc
+              class AppUserMapper < ROM::Mapper
+                relation :app_users
+
+                register_as :app_user
+
+                # specify model and attributes ie
+                #
+                # model AppUser
                 #
                 # attribute :name
                 # attribute :email


### PR DESCRIPTION
This PR will fix the Mapper generator to fix the `register_as` line.
Closes #54 

Thanks so much
:beers: 