### PR TITLE
Fix ROM-Rails resources URLs on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ To run tests:
 
 You can read more about ROM and Rails on the official website:
 
-* [Introduction to ROM](http://rom-rb.org/introduction/)
-* [Rails tutorial](http://rom-rb.org/tutorials/todo-app-with-rails/)
+* [Introduction to ROM](http://rom-rb.org/learn/)
+* [Rails setup](http://rom-rb.org/learn/setup/rails/)
 
 
 ## Community


### PR DESCRIPTION
This PR will fix the URLs of rom-rb oficial website. (The ToDo tutorial for rails was removed from the website. Don't know if it would be nice to put it again on the site)

Thanks,
:beers: