### PR TITLE
Multiple auto_registration paths

### DIFF
--- a/lib/rom/rails/configuration.rb
+++ b/lib/rom/rails/configuration.rb
@@ -9,6 +9,7 @@ module ROM
       include Virtus.model(strict: true)
 
       attribute :gateways, Hash, default: {}
+      attribute :auto_registration_paths, Array, default: []
 
       deprecate :repositories, :gateways
     end

--- a/spec/dummy/config/initializers/rom.rb
+++ b/spec/dummy/config/initializers/rom.rb
@@ -2,4 +2,5 @@ ROM::Rails::Railtie.configure do |config|
   scheme = RUBY_ENGINE == 'jruby' ? 'jdbc:sqlite' : 'sqlite'
   config.gateways[:default] = [:sql, "#{scheme}://#{Rails.root}/db/#{Rails.env}.sqlite3"]
   config.gateways[:test] = [:test_adapter, foo: :bar]
+  config.auto_registration_paths += [Rails.root.join('lib', 'additional_app')]
 end

--- a/spec/dummy/lib/additional_app/app/commands/create_additional_task.rb
+++ b/spec/dummy/lib/additional_app/app/commands/create_additional_task.rb
@@ -1,0 +1,5 @@
+class CreateAdditionalTask < ROM::Commands::Create[:sql]
+  relation :tasks
+  register_as :create_additional
+  result :one
+end

--- a/spec/integration/initializer_spec.rb
+++ b/spec/integration/initializer_spec.rb
@@ -8,4 +8,8 @@ describe 'ROM initializer' do
     expect(rom.gateways[:test]).to eql(gateway)
     expect(rom.relations.dummy).to eql(relation)
   end
+
+  it 'loads commands from additionall auto_registration_paths' do
+    expect(rom.commands.tasks.create_additional).to be_a(CreateAdditionalTask)
+  end
 end


### PR DESCRIPTION
I faced this problem when tried to use rom-rails inside Rails engine. It occurred that relations, mappers and commands are not being autoloaded from engine to the main app. Here I suggest adding this functionality.
