### PR TITLE
[WIP] Use rails5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 bundler_args: --without yard guard benchmarks
 script: "RAILS_ENV=test bundle exec rake app:db:reset app:spec"
 rvm:
-  - 2.1
   - 2.2
   - 2.3.1
   - rbx-2
@@ -13,6 +12,7 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: rbx-2
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,21 @@ cache: bundler
 bundler_args: --without yard guard benchmarks
 script: "RAILS_ENV=test bundle exec rake app:db:reset app:spec"
 rvm:
-  - 2.2
+  - 2.2.2
   - 2.3.1
   - rbx-2
   - jruby-9.0.5.0
   - ruby-head
+env:
+  - RAILS_VERSION=5.0.0
+  - RAILS_VERSION=4.2.0
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: rbx-2
+  exclude:
+    - rvm: rbx-2
+      env: RAILS_VERSION=5.0.0
 notifications:
   webhooks:
     urls:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-RAILS_VERSION = '~> 4.2.4'.freeze
+RAILS_VERSION = '~> 5.0.0'.freeze
 
 %w(railties actionview actionpack activerecord).each do |name|
   gem name, RAILS_VERSION
@@ -11,6 +11,7 @@ end
 gem 'sqlite3', platforms: [:mri, :rbx]
 gem 'byebug', platforms: :mri
 gem 'rom-sql', '~> 0.8'
+gem 'rom-model', github: 'rom-rb/rom-model', branch: 'master'
 
 platforms :jruby do
   gem 'jdbc-sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source 'https://rubygems.org'
 
 gemspec
 
-RAILS_VERSION = '~> 5.0.0'.freeze
+RAILS_VERSION = ENV.fetch("RAILS_VERSION", '5.0.0').freeze
 
 %w(railties actionview actionpack activerecord).each do |name|
-  gem name, RAILS_VERSION
+  gem name, "~> #{RAILS_VERSION}"
 end
 
 gem 'sqlite3', platforms: [:mri, :rbx]

--- a/lib/rom/rails/model/form.rb
+++ b/lib/rom/rails/model/form.rb
@@ -92,8 +92,9 @@ module ROM
 
       # @api private
       def initialize(params = {}, options = {})
-        @params = params
-        @model  = self.class.model.new(params.merge(options.slice(*self.class.key)))
+        @params = params.respond_to?(:to_unsafe_hash) ?
+          params.to_unsafe_hash : params
+        @model  = self.class.model.new(params.to_h.merge(options.slice(*self.class.key)))
         @result = nil
         @errors = ErrorProxy.new
         options.each { |key, value| instance_variable_set("@#{key}", value) }

--- a/rom-rails.gemspec
+++ b/rom-rails.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'addressable', '~> 2.3'
   spec.add_runtime_dependency 'charlatan', '~> 0.1'
   spec.add_runtime_dependency 'virtus', '~> 1.0', '>= 1.0.5'
-  spec.add_runtime_dependency 'railties', ['>= 3.0', '< 5.0']
+  spec.add_runtime_dependency 'railties', '>= 3.0', '< 6.0'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -10,8 +10,6 @@ require 'rspec-rails'
 
 module Dummy
   class Application < Rails::Application
-    config.assets.enabled = false
-
     require 'rom/test_adapter'
   end
 end


### PR DESCRIPTION
Allow rom-rails to work with rails5.

- [x] Loosen up the gem dependencies
- [ ] Address deprecation warnings.

The warnings mostly seem to be centered around a change to ActionController::Parameters, wherin it is no longer considered to be a Hash, and considers `to_h` to be unsafe ... 

```
DEPRECATION WARNING: Method to_hash is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.0/classes/ActionController/Parameters.html (called from new at /home/flip/src/rom-rb/rom-rails/lib/rom/rails/model/form.rb:96)
```

To be fair, in the pure context of a controller feeding parameters directly into a model create, it _is_ unsafe, and that's what `strong_parameters` was for.  However, in the context of a form object, like we have here, it's totally annoying....