### PR TITLE
Move validations

### DIFF
--- a/lib/rom/rails/model/form.rb
+++ b/lib/rom/rails/model/form.rb
@@ -115,10 +115,9 @@ module ROM
       #
       # @api public
       def save(*args)
-        @errors.clear
-        @result = commit!(*args)
+        validate!
 
-        @errors.set @result.error if result.respond_to? :error
+        @result = commit!(*args) unless @errors.present?
 
         self
       end
@@ -137,6 +136,7 @@ module ROM
       # @api public
       def validate!
         @errors.clear
+        return unless defined? self.class::Validator
         validator = self.class::Validator.new(attributes)
         validator.validate
 

--- a/lib/rom/rails/model/form.rb
+++ b/lib/rom/rails/model/form.rb
@@ -118,6 +118,7 @@ module ROM
         validate!
 
         @result = commit!(*args) unless @errors.present?
+        @errors.set @result.error if result.respond_to? :error
 
         self
       end

--- a/lib/rom/rails/model/form/class_interface.rb
+++ b/lib/rom/rails/model/form/class_interface.rb
@@ -428,7 +428,6 @@ module ROM
           klass = ConfigurationDSL::Command.build_class(name, rel_name, adapter: adapter)
 
           klass.result :one
-          klass.validator @validator
 
           relation = rom.relations[rel_name]
           gateway = rom.gateways[relation.gateway]

--- a/spec/dummy/app/commands/create_task_with_validations.rb
+++ b/spec/dummy/app/commands/create_task_with_validations.rb
@@ -1,0 +1,11 @@
+class CreateTaskWithValidations < CreateTask
+  register_as :create_task_with_validations
+
+  class Validator
+    include ROM::Model::Validator
+
+    validates :title, presence: true
+  end
+
+  validator Validator
+end

--- a/spec/integration/form_with_command_validation_spec.rb
+++ b/spec/integration/form_with_command_validation_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'Form with command supplied validations' do
+
+  subject(:form) { form_class.build(params) }
+
+  let(:params) {{}}
+
+  let(:form_class) do
+    Class.new(ROM::Model::Form) do
+      inject_commands_for :tasks
+
+      input do
+        set_model_name 'Task'
+
+        attribute :title
+      end
+
+      def commit!
+        tasks.try { tasks.create_task_with_validations.call(attributes) }
+      end
+    end
+  end
+
+
+  it "copies validation errors from command" do
+    form.save
+
+    errors = form.errors
+    expect(errors[:title]).to be_present
+  end
+
+end

--- a/spec/unit/form_spec.rb
+++ b/spec/unit/form_spec.rb
@@ -187,12 +187,12 @@ describe 'Form' do
 
   describe '#save' do
     it 'commits the form without extra args' do
-      result = form.build({}).save.result
+      result = form.build({email: 'jdoe@example.com'}).save.result
       expect(result).to eql('it works []')
     end
 
     it 'commits the form with extra args' do
-      result = form.build({}).save(1, 2, 3).result
+      result = form.build({email: 'jdoe@example.com'}).save(1, 2, 3).result
       expect(result).to eql('it works [1, 2, 3]')
     end
   end


### PR DESCRIPTION
This moves the point of validation from "injected into command" to occurring within the form itself, solely.

This accounts for the deprecation warning now raised by ROM-core, however there is a single expected deprecation warning from the tests, where the 'existing' behavior is explicitly supported, in the form of copying command validation errors over into the form's error object. This _only_ applies if the application is still explicitly assgning command validations; when that behavior is removed from core, the behavior in cd253a6 should be  reverted.