### PR TITLE
Update command generators

### DIFF
--- a/lib/generators/rom/commands/templates/create.rb.erb
+++ b/lib/generators/rom/commands/templates/create.rb.erb
@@ -3,6 +3,9 @@ class Create<%= model_name %> < ROM::Commands::Create<%= "[:#{adapter}]" %>
   register_as :create
   result :one
 
-  # define a validator to use
-  # validator <%= model_name %>Validator
+  # Override to specialize this command
+  def execute(tuples)
+    super tuples
+  end
+
 end

--- a/lib/generators/rom/commands/templates/create.rb.erb
+++ b/lib/generators/rom/commands/templates/create.rb.erb
@@ -1,10 +1,8 @@
-module <%= model_name %>Commands
-  class Create < ROM::Commands::Create<%= "[:#{adapter}]" %>
-    relation :<%= relation %>
-    register_as :create
-    result :one
+class Create<%= model_name %> < ROM::Commands::Create<%= "[:#{adapter}]" %>
+  relation :<%= relation %>
+  register_as :create
+  result :one
 
-    # define a validator to use
-    # validator <%= model_name %>Validator
-  end
+  # define a validator to use
+  # validator <%= model_name %>Validator
 end

--- a/lib/generators/rom/commands/templates/delete.rb.erb
+++ b/lib/generators/rom/commands/templates/delete.rb.erb
@@ -1,7 +1,5 @@
-module <%= model_name %>Commands
-  class Delete < ROM::Commands::Delete<%= "[:#{adapter}]" %>
-    relation :<%= relation %>
-    register_as :delete
-    result :one
-  end
+class Delete<%= model_name %> < ROM::Commands::Delete<%= "[:#{adapter}]" %>
+  relation :<%= relation %>
+  register_as :delete
+  result :one
 end

--- a/lib/generators/rom/commands/templates/delete.rb.erb
+++ b/lib/generators/rom/commands/templates/delete.rb.erb
@@ -2,4 +2,10 @@ class Delete<%= model_name %> < ROM::Commands::Delete<%= "[:#{adapter}]" %>
   relation :<%= relation %>
   register_as :delete
   result :one
+
+  # Override to specialize this command
+  def execute(tuples)
+    super tuples
+  end
+
 end

--- a/lib/generators/rom/commands/templates/update.rb.erb
+++ b/lib/generators/rom/commands/templates/update.rb.erb
@@ -3,6 +3,9 @@ class Update<%= model_name %> < ROM::Commands::Update<%= "[:#{adapter}]" %>
   register_as :update
   result :one
 
-  # define a validator to use
-  # validator <%= model_name %>Validator
+  # Override to specialize this command
+  def execute(tuples)
+    super tuples
+  end
+
 end

--- a/lib/generators/rom/commands/templates/update.rb.erb
+++ b/lib/generators/rom/commands/templates/update.rb.erb
@@ -1,10 +1,8 @@
-module <%= model_name %>Commands
-  class Update < ROM::Commands::Update<%= "[:#{adapter}]" %>
-    relation :<%= relation %>
-    register_as :update
-    result :one
+class Update<%= model_name %> < ROM::Commands::Update<%= "[:#{adapter}]" %>
+  relation :<%= relation %>
+  register_as :update
+  result :one
 
-    # define a validator to use
-    # validator <%= model_name %>Validator
-  end
+  # define a validator to use
+  # validator <%= model_name %>Validator
 end

--- a/lib/generators/rom/commands_generator.rb
+++ b/lib/generators/rom/commands_generator.rb
@@ -23,11 +23,7 @@ module ROM
       private
 
       def command_file(command)
-        File.join('app', 'commands', command_dir, "#{command}.rb")
-      end
-
-      def command_dir
-        "#{class_name.downcase.singularize}_commands"
+        File.join('app', 'commands', "#{command}_#{model_name.downcase}.rb")
       end
 
       def relation

--- a/spec/lib/generators/commands_generator_spec.rb
+++ b/spec/lib/generators/commands_generator_spec.rb
@@ -17,11 +17,9 @@ describe ROM::Generators::CommandsGenerator do
     expect(destination_root).to have_structure {
       directory 'app' do
         directory 'commands' do
-          directory 'user_commands' do
-            file 'create.rb' do
-              contains <<-CONTENT.strip_heredoc
-                module UserCommands
-                  class Create < ROM::Commands::Create[:#{default_adapter}]
+          file 'create_user.rb' do
+            contains <<-CONTENT.strip_heredoc
+                  class CreateUser < ROM::Commands::Create[:#{default_adapter}]
                     relation :users
                     register_as :create
                     result :one
@@ -29,14 +27,12 @@ describe ROM::Generators::CommandsGenerator do
                     # define a validator to use
                     # validator UserValidator
                   end
-                end
-              CONTENT
-            end
+            CONTENT
+          end
 
-            file 'update.rb' do
-              contains <<-CONTENT.strip_heredoc
-                module UserCommands
-                  class Update < ROM::Commands::Update[:#{default_adapter}]
+          file 'update_user.rb' do
+            contains <<-CONTENT.strip_heredoc
+                  class UpdateUser < ROM::Commands::Update[:#{default_adapter}]
                     relation :users
                     register_as :update
                     result :one
@@ -44,21 +40,17 @@ describe ROM::Generators::CommandsGenerator do
                     # define a validator to use
                     # validator UserValidator
                   end
-                end
-              CONTENT
-            end
+            CONTENT
+          end
 
-            file 'delete.rb' do
-              contains <<-CONTENT.strip_heredoc
-                module UserCommands
-                  class Delete < ROM::Commands::Delete[:#{default_adapter}]
+          file 'delete_user.rb' do
+            contains <<-CONTENT.strip_heredoc
+                  class DeleteUser < ROM::Commands::Delete[:#{default_adapter}]
                     relation :users
                     register_as :delete
                     result :one
                   end
-                end
-              CONTENT
-            end
+            CONTENT
           end
         end
       end
@@ -68,13 +60,13 @@ describe ROM::Generators::CommandsGenerator do
   specify "with given adapter" do
     run_generator ['users', '--adapter=memory']
 
-    create = File.read(File.join(destination_root, 'app', 'commands', 'user_commands', 'create.rb'))
-    expect(create).to include("class Create < ROM::Commands::Create[:memory]")
+    create = File.read(File.join(destination_root, 'app', 'commands', 'create_user.rb'))
+    expect(create).to include("class CreateUser < ROM::Commands::Create[:memory]")
 
-    update = File.read(File.join(destination_root, 'app', 'commands', 'user_commands', 'update.rb'))
-    expect(update).to include("class Update < ROM::Commands::Update[:memory]")
+    update = File.read(File.join(destination_root, 'app', 'commands', 'update_user.rb'))
+    expect(update).to include("class UpdateUser < ROM::Commands::Update[:memory]")
 
-    delete = File.read(File.join(destination_root, 'app', 'commands', 'user_commands', 'delete.rb'))
-    expect(delete).to include("class Delete < ROM::Commands::Delete[:memory]")
+    delete = File.read(File.join(destination_root, 'app', 'commands', 'delete_user.rb'))
+    expect(delete).to include("class DeleteUser < ROM::Commands::Delete[:memory]")
   end
 end

--- a/spec/lib/generators/commands_generator_spec.rb
+++ b/spec/lib/generators/commands_generator_spec.rb
@@ -24,8 +24,11 @@ describe ROM::Generators::CommandsGenerator do
                     register_as :create
                     result :one
 
-                    # define a validator to use
-                    # validator UserValidator
+                    # Override to specialize this command
+                    def execute(tuples)
+                      super tuples
+                    end
+
                   end
             CONTENT
           end
@@ -37,8 +40,11 @@ describe ROM::Generators::CommandsGenerator do
                     register_as :update
                     result :one
 
-                    # define a validator to use
-                    # validator UserValidator
+                    # Override to specialize this command
+                    def execute(tuples)
+                      super tuples
+                    end
+
                   end
             CONTENT
           end
@@ -49,6 +55,12 @@ describe ROM::Generators::CommandsGenerator do
                     relation :users
                     register_as :delete
                     result :one
+
+                    # Override to specialize this command
+                    def execute(tuples)
+                      super tuples
+                    end
+
                   end
             CONTENT
           end


### PR DESCRIPTION
A few tweaks to modernize the command generators:

Flatten the generated directory structure, so its less confused.
Provide a hint for overriding the execute method, so users will have some guidance on _where_ to go
Remove the hint for the deprecated validator method