### PR TITLE
Remove charlatan runtime dependency

### DIFF
--- a/rom-rails.gemspec
+++ b/rom-rails.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-core', '~> 0.2', '>= 0.2.4'
   spec.add_runtime_dependency 'addressable', '~> 2.3'
-  spec.add_runtime_dependency 'charlatan', '~> 0.1'
   spec.add_runtime_dependency 'railties', '>= 3.0', '< 6.0'
 
   spec.add_development_dependency "rom-repository"


### PR DESCRIPTION
Charlatan was removed in this commit
https://github.com/rom-rb/rom-rails/commit/2613a1ec64f34bf9bce98ceaacfecb1644d6da5e#diff-8d714453b1415ca9883197befff1600aL1