### PR TITLE
Broadcast ROM output to STDOUT during `rails c`

### DIFF
--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -43,7 +43,14 @@ module ROM
       config.to_prepare do |_config|
         ROM.env = Railtie.create_container
       end
-
+      
+      console do |app|
+        unless ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDERR, STDOUT)
+          console = ActiveSupport::Logger.new(STDERR)
+          Rails.logger.extend ActiveSupport::Logger.broadcast console
+        end
+      end
+      
       # Behaves like `Railtie#configure` if the given block does not take any
       # arguments. Otherwise yields the ROM configuration to the block.
       #


### PR DESCRIPTION
When running ROM queries in `rails c`, we should see the SQL it is executing, similar to how Active Record does it.

I've borrowed some lines here for `rom-rails` to use from active_record's codebase. I don't think they'll mind.

```
irb(main):002:0> repo.create(name: "omg")
  ROM[postgres] (0.2ms)  SET standard_conforming_strings = ON
  ROM[postgres] (0.2ms)  SET client_min_messages = 'WARNING'
  ROM[postgres] (0.2ms)  SET DateStyle = 'ISO'
  ROM[postgres] (4.4ms)  INSERT INTO "projects" ("name") VALUES ('omg') RETURNING "projects"."id", "projects"."name"
=> #<Project:0x00007fe45f3b6438 @id=12, @name="omg">
```