### PR TITLE
Remove relation config from mapper template

### DIFF
--- a/lib/generators/rom/mapper/templates/mapper.rb.erb
+++ b/lib/generators/rom/mapper/templates/mapper.rb.erb
@@ -1,6 +1,4 @@
 class <%= model_name %>Mapper < ROM::Mapper
-  relation :<%= relation %>
-
   register_as :<%= register_as %>
 
   # specify model and attributes ie


### PR DESCRIPTION
I think these two options are only used here in `ROM::Mapper`:

https://github.com/rom-rb/rom/blob/131ad48d364a25a75cb01fb37bf0e99458b1073e/mapper/lib/rom/mapper.rb#L68-L73

So with the `register_at` taking precedence over `relation`, I think we only need to specify the `register_at` config option, rather than the relation too.