### PR TITLE
Use Rails application name to namespace entities

### DIFF
--- a/lib/generators/rom/repository/templates/repository.rb.erb
+++ b/lib/generators/rom/repository/templates/repository.rb.erb
@@ -1,5 +1,6 @@
 class <%= model_name %>Repository < ROM::Repository::Root
   root <%= ":#{relation}" %>
 
-  commands :create, update: :by_pk, delete: :by_pk, mapper: :<%= mapper %>
+  commands :create, update: :by_pk, delete: :by_pk
+  struct_namespace <%= Rails.application.class.name.split("::").first %>
 end


### PR DESCRIPTION
@solnic has recommended to me for Exploding Rails that I should get rid of mappers and use `struct_namespace` instead. I think `rom-rails` should encourage this too, by using `struct_namespace` with the class name of the application when generating repositories.