### PR TITLE
Use default adapter

### DIFF
--- a/lib/generators/rom.rb
+++ b/lib/generators/rom.rb
@@ -18,6 +18,14 @@ module ROM
           __FILE__
         )
       end
+
+      def self.default_gateway
+        ROM.env.gateways[:default]
+      end
+
+      def self.default_adapter
+        (default_gateway && default_gateway.adapter)
+      end
     end
   end
 end

--- a/lib/generators/rom/commands/templates/create.rb.erb
+++ b/lib/generators/rom/commands/templates/create.rb.erb
@@ -3,9 +3,7 @@ class Create<%= model_name %> < ROM::Commands::Create<%= "[:#{adapter}]" %>
   register_as :create
   result :one
 
-<% if adapter.to_sym == :sql -%>
   # set Timestamp plugin
   # use :timestamps
   # timestamp :created_at, :updated_at
-<% end -%>
 end

--- a/lib/generators/rom/commands/templates/delete.rb.erb
+++ b/lib/generators/rom/commands/templates/delete.rb.erb
@@ -2,5 +2,4 @@ class Delete<%= model_name %> < ROM::Commands::Delete<%= "[:#{adapter}]" %>
   relation :<%= relation %>
   register_as :delete
   result :one
-
 end

--- a/lib/generators/rom/commands/templates/update.rb.erb
+++ b/lib/generators/rom/commands/templates/update.rb.erb
@@ -3,9 +3,7 @@ class Update<%= model_name %> < ROM::Commands::Update<%= "[:#{adapter}]" %>
   register_as :update
   result :one
 
-<% if adapter.to_sym == :sql -%>
   # set Timestamp plugin
   # use :timestamps
   # timestamp :updated_at
-<% end -%>
 end

--- a/lib/generators/rom/commands_generator.rb
+++ b/lib/generators/rom/commands_generator.rb
@@ -6,7 +6,7 @@ module ROM
       class_option :adapter,
         banner: "--adapter=adapter",
         desc: "specify an adapter to use", required: true,
-        default: ROM.adapters.keys.first
+        default: default_adapter
 
       def create_create_command
         template 'create.rb.erb', command_file(:create)

--- a/lib/generators/rom/relation_generator.rb
+++ b/lib/generators/rom/relation_generator.rb
@@ -3,12 +3,10 @@ require 'generators/rom'
 module ROM
   module Generators
     class RelationGenerator < Base
-      default_gateway = ROM.env.gateways[:default]
-
       class_option :adapter,
         banner: "--adapter=adapter",
         desc: "specify an adapter to use", required: true,
-        default: ((default_gateway && default_gateway.adapter) || ROM.adapters.keys.first)
+        default: default_adapter
 
       class_option :gateway,
         banner: "--gateway=repo",

--- a/spec/lib/generators/commands_generator_spec.rb
+++ b/spec/lib/generators/commands_generator_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe ROM::Generators::CommandsGenerator do
                     relation :users
                     register_as :delete
                     result :one
-
                   end
             CONTENT
           end

--- a/spec/lib/generators/commands_generator_spec.rb
+++ b/spec/lib/generators/commands_generator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ROM::Generators::CommandsGenerator do
   specify do
     run_generator ['users']
 
-    default_adapter = ROM.adapters.keys.first
+    default_adapter = ROM.env.gateways[:default].adapter
 
     expect(destination_root).to have_structure {
       directory 'app' do


### PR DESCRIPTION
comands generator should also use default gateway's adapter
    
Pull the discovery out to the base class.  If there is no default gateway, don't make any assumptions

fixes #92 

