### PR TITLE
Escape username and password for special characters

### DIFF
--- a/lib/rom/rails/active_record/configuration.rb
+++ b/lib/rom/rails/active_record/configuration.rb
@@ -86,8 +86,8 @@ module ROM
         def self.generic_uri(config)
           build_uri(
             scheme: config.fetch(:scheme),
-            user: config[:username],
-            password: config[:password],
+            user: escape_option(config[:username]),
+            password: escape_option(config[:password]),
             host: config[:host],
             port: config[:port],
             path: config[:database]
@@ -96,6 +96,10 @@ module ROM
 
         def self.build_uri(attrs)
           Addressable::URI.new(attrs).to_s
+        end
+
+        def self.escape_option(option)
+          option.nil? ? option : CGI.escape(option)
         end
       end
     end

--- a/spec/lib/active_record/configuration_spec.rb
+++ b/spec/lib/active_record/configuration_spec.rb
@@ -112,6 +112,22 @@ RSpec.describe ROM::Rails::ActiveRecord::Configuration do
 
         expect(read(config)).to eq uri: expected_uri, options: { pool: 5 }
       end
+
+      it 'handles special characters in username and password' do
+        config = {
+          pool: 5,
+          adapter: 'mysql2',
+          username: 'r@o%ot',
+          password: 'p@ssw0rd#',
+          database: 'database',
+          host: 'example.com'
+        }
+
+        expected_uri = 'mysql2://r%40o%25ot:p%40ssw0rd%23@example.com/database'
+        expected_uri = "jdbc:#{expected_uri}" if RUBY_ENGINE == 'jruby'
+
+        expect(read(config)).to eq uri: expected_uri, options: { pool: 5 }
+      end
     end
   end
 end


### PR DESCRIPTION
Sequel expects valid connection string (URI) which is not met with special characters in password or username.

See https://github.com/jeremyevans/sequel/issues/1361 for details.

I am getting:

```
....

4: from /Volumes/Data/Users/cervajz/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sequel-5.13.0/lib/sequel/core.rb:121:in `connect'
	 3: from /Volumes/Data/Users/cervajz/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sequel-5.13.0/lib/sequel/database/connecting.rb:34:in `connect'
	 2: from /Volumes/Data/Users/cervajz/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/common.rb:237:in `parse'
	 1: from /Volumes/Data/Users/cervajz/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/rfc3986_parser.rb:73:in `parse'
/Volumes/Data/Users/cervajz/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/rfc3986_parser.rb:67:in `split': bad URI(is not URI?): postgres://root:p@ssword@localhost:5432/api_virtio_development (URI::InvalidURIError)
```