### PR TITLE
Do not output log messages twice when ActiveRecord present

### DIFF
--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -46,10 +46,7 @@ module ROM
       end
 
       console do |_app|
-        unless ActiveSupport::Logger.logger_outputs_to?(::Rails.logger, STDERR, STDOUT)
-          console = ActiveSupport::Logger.new(STDERR)
-          ::Rails.logger.extend ActiveSupport::Logger.broadcast console
-        end
+        Railtie.configure_console_logger
       end
 
       # Behaves like `Railtie#configure` if the given block does not take any
@@ -136,6 +133,19 @@ module ROM
       # @api private
       def active_record?
         defined?(::ActiveRecord)
+      end
+
+      # @api private
+      def std_err_out_logger?
+        ActiveSupport::Logger.logger_outputs_to?(::Rails.logger, STDERR, STDOUT)
+      end
+
+      # @api private
+      def configure_console_logger
+        return if active_record? || std_err_out_logger?
+
+        console = ActiveSupport::Logger.new(STDERR)
+        ::Rails.logger.extend ActiveSupport::Logger.broadcast console
       end
     end
   end


### PR DESCRIPTION
ActiveRecord creates its own console output to STDERR and STDOUT and
it looks like the #logger_outputs_to? does not catch that. The result is
is having the log messages twice in rails console.

More info:
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/railtie.rb#L58