### PR TITLE
Rom5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,19 @@ cache: bundler
 bundler_args: --without yard guard benchmarks
 script: "RAILS_ENV=test bundle exec rake app:db:reset app:spec"
 rvm:
-  - 2.3.1
-  - 2.4.1
-  - jruby-9.1.13.0
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
+  - jruby-9.2.7.0
 env:
-  - RAILS_VERSION=5.1.0
-  - RAILS_VERSION=5.0.0
-  - RAILS_VERSION=4.2.0
+  - RAILS_VERSION=5.2
+  - RAILS_VERSION=5.1
+  - RAILS_VERSION=5.0
+  - RAILS_VERSION=4.2
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/39e1225f489f38b0bd09
+      - https://rom-rb.zulipchat.com/api/v1/external/travis?api_key=S1S2GRkXHlzlaCGyUwm7o4lg50IZrwCH&stream=notifications&topic=ci
     on_success: change
     on_failure: always
     on_start: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v2.0.0 2019-04-26
+
+### Changed
+
+* Updated to depend on rom-* 5.0
+
+[Compare v1.3.0...v2.0.0](https://github.com/rom-rb/rom-rails/compare/v1.3.0...v2.0.0)
+
 ## v1.3.0 2018-11-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v2.0.0 2019-04-26
+## v2.0.0 to-be-released
 
 ### Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'rom', git: 'https://github.com/rom-rb/rom', branch: 'master' do
   gem 'rom-repository', group: :tools
 end
 
-gem 'rom-http'
 gem 'rom-sql', github: 'rom-rb/rom-sql', branch: 'master'
 
 platforms :jruby do

--- a/rom-rails.gemspec
+++ b/rom-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-core', '~> 0.3'
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'railties', '>= 3.0', '< 6.0'
-  spec.add_runtime_dependency 'rom', '~> 4.0'
+  spec.add_runtime_dependency 'rom', '~> 5.0'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/spec/dummy/config/initializers/rom.rb
+++ b/spec/dummy/config/initializers/rom.rb
@@ -1,6 +1,6 @@
 ROM::Rails::Railtie.configure do |config|
   scheme = RUBY_ENGINE == 'jruby' ? 'jdbc:sqlite' : 'sqlite'
-  config.gateways[:arro] = [:http, uri: 'http://example.org' ]
+  config.gateways[:arro] = [:test_adapter, uri: 'http://example.org' ]
   config.gateways[:sql] = [:sql, "#{scheme}://#{Rails.root}/db/#{Rails.env}.sqlite3"]
   config.gateways[:default] = [:test_adapter, foo: :bar]
   config.auto_registration_paths += [Rails.root.join('lib', 'additional_app', 'persistence')]


### PR DESCRIPTION
Update to require rom 5.0

Nothing breaks in this gem, but the 5.0 change pulls in dry-types 1.0, which _is_ a breaking change; and it's probably better to signal up and down the stack ...