### PR TITLE
Handle rails6 config

### DIFF
--- a/lib/rom/rails/active_record/configuration.rb
+++ b/lib/rom/rails/active_record/configuration.rb
@@ -1,4 +1,4 @@
-require 'addressable/uri'
+require_relative 'uri_builder'
 
 module ROM
   module Rails
@@ -43,64 +43,12 @@ module ROM
           uri_options = config.except(:adapter).merge(scheme: adapter)
           other_options = config.except(*BASE_OPTIONS)
 
-          builder_method = :"#{adapter}_uri"
-          uri = if respond_to?(builder_method)
-                  send(builder_method, uri_options)
-                else
-                  generic_uri(uri_options)
-                end
+          builder = ROM::Rails::ActiveRecord::UriBuilder.new
 
-          # JRuby connection strings require special care.
-          if RUBY_ENGINE == 'jruby' && adapter != 'postgresql'
-            uri = "jdbc:#{uri}"
-          end
-
+          uri = builder.build(adapter, uri_options)
           { uri: uri, options: other_options }
         end
 
-        def self.sqlite3_uri(config)
-          path = Pathname.new(config.fetch(:root)).join(config.fetch(:database))
-
-          build_uri(
-            scheme: 'sqlite',
-            host: '',
-            path: path.to_s
-          )
-        end
-
-        def self.postgresql_uri(config)
-          generic_uri(config.merge(
-                        host: config.fetch(:host) { '' },
-                        scheme: 'postgres'
-                      ))
-        end
-
-        def self.mysql_uri(config)
-          if config.key?(:username) && !config.key?(:password)
-            config.update(password: '')
-          end
-
-          generic_uri(config)
-        end
-
-        def self.generic_uri(config)
-          build_uri(
-            scheme: config.fetch(:scheme),
-            user: escape_option(config[:username]),
-            password: escape_option(config[:password]),
-            host: config[:host],
-            port: config[:port],
-            path: config[:database]
-          )
-        end
-
-        def self.build_uri(attrs)
-          Addressable::URI.new(attrs).to_s
-        end
-
-        def self.escape_option(option)
-          option.nil? ? option : CGI.escape(option)
-        end
       end
     end
   end

--- a/lib/rom/rails/active_record/configuration.rb
+++ b/lib/rom/rails/active_record/configuration.rb
@@ -17,15 +17,29 @@ module ROM
           :host
         ].freeze
 
+        attr_reader :configurations
+        attr_reader :env
+        attr_reader :root
+        attr_reader :uri_builder
+
+        def initialize(env: ::Rails.env, root: ::Rails.root, base: ::ActiveRecord::Base)
+          @configurations = base.configurations
+          @env  = env
+          @root = root
+
+          @uri_builder = ROM::Rails::ActiveRecord::UriBuilder.new
+        end
+
+
         # Returns gateway configuration for the current environment.
         #
         # @note This relies on ActiveRecord being initialized already.
         # @param [Rails::Application]
         #
         # @api private
-        def self.call
-          configuration = ::ActiveRecord::Base.configurations.fetch(::Rails.env)
-          build(configuration.symbolize_keys.update(root: ::Rails.root))
+        def call
+          configuration = configurations.fetch(env)
+          build(configuration.symbolize_keys.update(root: root))
         end
 
         # Builds a configuration hash from a flat database config hash.
@@ -38,14 +52,12 @@ module ROM
         # @return [Hash]
         #
         # @api private
-        def self.build(config)
+        def build(config)
           adapter = config.fetch(:adapter)
           uri_options = config.except(:adapter).merge(scheme: adapter)
           other_options = config.except(*BASE_OPTIONS)
 
-          builder = ROM::Rails::ActiveRecord::UriBuilder.new
-
-          uri = builder.build(adapter, uri_options)
+          uri = uri_builder.build(adapter, uri_options)
           { uri: uri, options: other_options }
         end
 

--- a/lib/rom/rails/active_record/configuration.rb
+++ b/lib/rom/rails/active_record/configuration.rb
@@ -22,14 +22,13 @@ module ROM
         attr_reader :root
         attr_reader :uri_builder
 
-        def initialize(env: ::Rails.env, root: ::Rails.root, base: ::ActiveRecord::Base)
-          @configurations = base.configurations
+        def initialize(env: ::Rails.env, root: ::Rails.root, configurations: ::ActiveRecord::Base.configurations)
+          @configurations = configurations
           @env  = env
           @root = root
 
           @uri_builder = ROM::Rails::ActiveRecord::UriBuilder.new
         end
-
 
         # Returns gateway configuration for the current environment.
         #

--- a/lib/rom/rails/active_record/configuration.rb
+++ b/lib/rom/rails/active_record/configuration.rb
@@ -38,7 +38,12 @@ module ROM
         #
         # @api private
         def call
-          configuration = configurations.fetch(env)
+          configuration = if ::ActiveRecord::VERSION::MAJOR < 6
+                            configurations.fetch(env)
+                          else
+                            configurations.default_hash(env)
+                          end
+
           build(configuration.symbolize_keys.update(root: root))
         end
 

--- a/lib/rom/rails/active_record/uri_builder.rb
+++ b/lib/rom/rails/active_record/uri_builder.rb
@@ -1,0 +1,72 @@
+require 'addressable/uri'
+
+module ROM
+  module Rails
+    module ActiveRecord
+      class UriBuilder
+
+        def build(adapter, uri_options)
+          builder_method = :"#{adapter}_uri"
+
+          uri = if respond_to?(builder_method)
+                  send(builder_method, uri_options)
+                else
+                  generic_uri(uri_options)
+                end
+
+          # JRuby connection strings require special care.
+          if RUBY_ENGINE == 'jruby' && adapter != 'postgresql'
+            uri = "jdbc:#{uri}"
+          end
+
+          uri
+        end
+
+
+        def sqlite3_uri(config)
+          path = Pathname.new(config.fetch(:root)).join(config.fetch(:database))
+
+          build_uri(
+            scheme: 'sqlite',
+            host: '',
+            path: path.to_s
+          )
+        end
+
+        def postgresql_uri(config)
+          generic_uri(config.merge(
+                        host: config.fetch(:host) { '' },
+                        scheme: 'postgres'
+                      ))
+        end
+
+        def mysql_uri(config)
+          if config.key?(:username) && !config.key?(:password)
+            config.update(password: '')
+          end
+
+          generic_uri(config)
+        end
+
+        def generic_uri(config)
+          build_uri(
+            scheme: config.fetch(:scheme),
+            user: escape_option(config[:username]),
+            password: escape_option(config[:password]),
+            host: config[:host],
+            port: config[:port],
+            path: config[:database]
+          )
+        end
+
+        def build_uri(attrs)
+          Addressable::URI.new(attrs).to_s
+        end
+
+        def escape_option(option)
+          option.nil? ? option : CGI.escape(option)
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -86,7 +86,9 @@ module ROM
 
       # @api private
       def gateways
-        config.rom.gateways[:default] ||= infer_default_gateway if active_record?
+        if active_record?
+          config.rom.gateways[:default] ||= infer_default_gateway
+        end
 
         if config.rom.gateways.empty?
           ::Rails.logger.warn "It seems that you have not configured any gateways"
@@ -102,7 +104,8 @@ module ROM
       #
       # @api private
       def infer_default_gateway
-        spec = ROM::Rails::ActiveRecord::Configuration.call
+        ar_config = ROM::Rails::ActiveRecord::Configuration.new
+        spec = ROM::Rails::ActiveRecord::Configuration.new.call
         [:sql, spec[:uri], spec[:options]]
       end
 

--- a/spec/lib/active_record/configuration_spec.rb
+++ b/spec/lib/active_record/configuration_spec.rb
@@ -1,7 +1,10 @@
 require 'rom/rails/active_record/configuration'
+require 'active_record'
 
 RSpec.describe ROM::Rails::ActiveRecord::Configuration do
   let(:root) { Pathname.new('/path/to/app') }
+
+  subject(:configuration) { described_class.new }
 
   def uri_for(config)
     result = read(config)
@@ -9,7 +12,7 @@ RSpec.describe ROM::Rails::ActiveRecord::Configuration do
   end
 
   def read(config)
-    described_class.build(config.merge(root: root))
+    configuration.build(config.merge(root: root))
   end
 
   def parse(uri)

--- a/spec/lib/active_record/configuration_spec.rb
+++ b/spec/lib/active_record/configuration_spec.rb
@@ -4,7 +4,7 @@ require 'active_record'
 RSpec.describe ROM::Rails::ActiveRecord::Configuration do
   let(:root) { Pathname.new('/path/to/app') }
 
-  subject(:configuration) { described_class.new }
+  subject(:configuration) { described_class.new(root: root) }
 
   def uri_for(config)
     result = read(config)
@@ -12,7 +12,7 @@ RSpec.describe ROM::Rails::ActiveRecord::Configuration do
   end
 
   def read(config)
-    configuration.build(config.merge(root: root))
+    configuration.build(config)
   end
 
   def parse(uri)


### PR DESCRIPTION
Attempt to cleanly handle the new database configuration structures in Rails6.

Rails6 introduces a new configuration object, rather than keeping just a hash of connection options.  Let's verify that we can use that object.

This should handle the base, legacy case for configuration keys, and fix #104.  Handling the new multiple-database configuration is going to take another few refinements.