### PR TITLE
Allow Rails 6.1.1 to use ROM-Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-RAILS_VERSION = ENV.fetch("RAILS_VERSION", '6.0.0').freeze
+RAILS_VERSION = ENV.fetch("RAILS_VERSION", '6.1.1').freeze
 
 %w(railties actionview actionpack activerecord).each do |name|
   gem name, "~> #{RAILS_VERSION}"

--- a/rom-rails.gemspec
+++ b/rom-rails.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'addressable', '~> 2.3'
-  spec.add_runtime_dependency 'dry-core', '~> 0.3'
+  spec.add_runtime_dependency 'dry-core', '~> 0.4'
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
-  spec.add_runtime_dependency 'railties', '>= 3.0', '< 6.1'
-  spec.add_runtime_dependency 'rom', '~> 5.0'
+  spec.add_runtime_dependency 'railties', '>= 3.0', '< 6.2'
+  spec.add_runtime_dependency 'rom', '~> 5.2'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/rom-rails.gemspec
+++ b/rom-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-core', '~> 0.4'
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'railties', '>= 3.0', '< 6.2'
-  spec.add_runtime_dependency 'rom', '~> 5.2'
+  spec.add_runtime_dependency 'rom', '>= 5.0'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
ROM-Rails work perfectly with Rails 6.1, but the gemspec forbid this to happen.
