### PR TITLE
Allow rails6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 2.7
   - jruby-9.2.16.0
 env:
+  - RAILS_VERSION=6.1
   - RAILS_VERSION=6.0
   - RAILS_VERSION=5.2
   - RAILS_VERSION=5.1
@@ -26,5 +27,7 @@ matrix:
   exclude:
     - rvm: 2.4
       env: RAILS_VERSION=6.0
+    - rvm: 2.4
+      env: RAILS_VERSION=6.1
     - rvm: 2.7
       env: RAILS_VERSION=4.2

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-RAILS_VERSION = ENV.fetch("RAILS_VERSION", '6.0.0').freeze
+RAILS_VERSION = ENV.fetch("RAILS_VERSION", '6.1.1').freeze
 
 %w(railties actionview actionpack activerecord).each do |name|
   gem name, "~> #{RAILS_VERSION}"

--- a/rom-rails.gemspec
+++ b/rom-rails.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'addressable', '~> 2.3'
-  spec.add_runtime_dependency 'dry-core', '~> 0.3'
+  spec.add_runtime_dependency 'dry-core', '~> 0.4'
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
-  spec.add_runtime_dependency 'railties', '>= 3.0', '< 6.1'
-  spec.add_runtime_dependency 'rom', '~> 5.0'
+  spec.add_runtime_dependency 'railties', '>= 3.0', '< 6.2'
+  spec.add_runtime_dependency 'rom', '~> 5.2'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Update gemspecs to allow rails 6.1.  Add to the build matrix


partially cherrypicked off #116 