### PR TITLE
Allow not to reload database on each requests

### DIFF
--- a/lib/rom/rails/configuration.rb
+++ b/lib/rom/rails/configuration.rb
@@ -13,6 +13,10 @@ module ROM
       config_accessor :auto_registration_paths do
         ['app']
       end
+
+      config_accessor :reload_on_each_request do
+        true
+      end
     end
   end
 end

--- a/lib/rom/rails/railtie.rb
+++ b/lib/rom/rails/railtie.rb
@@ -40,9 +40,18 @@ module ROM
         load "rom/rails/tasks/db.rake" unless active_record?
       end
 
+      # Load ROM-related application code on startup
+      config.after_initialize do
+        if !::Rails.application.config.rom.reload_on_each_request
+          ROM.env = Railtie.create_container
+        end
+      end
+
       # Reload ROM-related application code on each request.
-      config.to_prepare do |_config|
-        ROM.env = Railtie.create_container
+      config.to_prepare do |prepare_conf|
+        if ::Rails.application.config.rom.reload_on_each_request
+          ROM.env = Railtie.create_container
+        end
       end
 
       console do |_app|


### PR DESCRIPTION
When developing, file change causes ROM-Rails to rebuild the container, this leads to a database reload.
It works well with a small database, but when you stack up more and more tables, it takes more and more time.

This allows to only load the database container at launch.

It's disabled by default.

Possible errors : 
- Database desync if migration is run.