### PR TITLE
tag for a new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v2.4.0 2023-10-26c
+
+### Changed
+
+* Add configuration to allow not trigger reload on each request (alex-lairan)
+* Allow namespace configuration from within an auto_registration path (sasa-b)
+
+### Added 
+
+* Compatible with Rails 7.0 (nolantait)
+* Compatible with Rails 7.1 (cflipse)
+
+### Removed
+
+* Dropped support for Rails < 6.0
+* Dropped support for Ruby < 2.7
+
 ## v2.3.0 2021-03-20
 
 ### Changed

--- a/lib/rom/rails/version.rb
+++ b/lib/rom/rails/version.rb
@@ -1,5 +1,5 @@
 module ROM
   module Rails
-    VERSION = '2.3.0'.freeze
+    VERSION = '2.4.0'.freeze
   end
 end

--- a/rom-rails.gemspec
+++ b/rom-rails.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'addressable', '~> 2.3'
   spec.add_runtime_dependency 'dry-core', '~> 1.0'
-  spec.add_runtime_dependency 'railties', '>= 3.0', '<= 7.0.4'
+  spec.add_runtime_dependency 'railties', '>= 6.0', '< 8.0.0'
   spec.add_runtime_dependency 'rom', '~> 5.3'
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Tag for release.

This drops support for Ruby < 2.7, and for Rails < 6.0   

I'm not entirely certain if I should take that as a queue to bump the semver major up to 3.0 or not.  @solnic  do you have a thought there?