### PR TITLE
Removed ActiveSupport::Configurable usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :test do
   gem 'generator_spec'
   gem 'rack-test'
   gem 'rspec-rails', '~> 3.1'
+  gem 'benchmark'
   gem 'mutex_m'
   gem 'base64'
   gem 'drb'

--- a/lib/rom/rails/configuration.rb
+++ b/lib/rom/rails/configuration.rb
@@ -1,21 +1,12 @@
-require 'dry/core/deprecations'
-
 module ROM
   module Rails
     class Configuration
-      extend Dry::Core::Deprecations[:configuration]
-      include ActiveSupport::Configurable
+      attr_accessor :gateways, :auto_registration_paths, :reload_on_each_request
 
-      config_accessor :gateways do
-        {}
-      end
-
-      config_accessor :auto_registration_paths do
-        ['app']
-      end
-
-      config_accessor :reload_on_each_request do
-        true
+      def initialize
+        @gateways = {}
+        @auto_registration_paths = ['app']
+        @reload_on_each_request = true
       end
     end
   end


### PR DESCRIPTION
ActiveSupport::Configurable is deprecated in Rails 8.1, and will be removed in Rails 8.2 per this warning:

```bash
DEPRECATION WARNING: ActiveSupport::Configurable is deprecated without replacement, and will be removed in Rails 8.2.
```

This commit also adds Ruby 4.0 to the test matrix for completeness.